### PR TITLE
Add cluster module

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tflint:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout source code
+
+    - uses: actions/cache@v4
+      name: Cache plugin dir
+      with:
+        path: ~/.tflint.d/plugins
+        key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
+    - uses: terraform-linters/setup-tflint@v4
+      name: Setup TFLint
+      with:
+        tflint_version: v0.52.0
+
+    - name: Show version
+      run: tflint --version
+
+    - name: Init TFLint
+      run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Run TFLint
+      run: tflint -f compact

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+docs:
+	terraform-docs markdown table --output-file README.md --output-mode inject .

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ No modules.
 | <a name="input_enable_live_migration_agent"></a> [enable\_live\_migration\_agent](#input\_enable\_live\_migration\_agent) | Whether to enable the live migration agent | `bool` | `false` | no |
 | <a name="input_enable_scheduler"></a> [enable\_scheduler](#input\_enable\_scheduler) | Whether to enable the scheduler | `bool` | `true` | no |
 | <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | The endpoint of the control plane | `string` | `"https://dakr.devzero.io"` | no |
-| <a name="input_operator_annotations"></a> [operator\_annotations](#input\_operator\_annotations) | The annotations to add to the operator | `map(string)` | `{}` | no |
 | <a name="input_operator_extra_values"></a> [operator\_extra\_values](#input\_operator\_extra\_values) | Additional Helm values for the devzero-operator chart (as name->value). | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_provision_prometheus"></a> [provision\_prometheus](#input\_provision\_prometheus) | Whether to provision prometheus | `bool` | `true` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The runtime of the cluster. Supported values: containerd, rke2, k3s. | `string` | `"containerd"` | no |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# terraform-devzero-modules
+# Terraform module for adding a cluster to your devzero account
+
+Website: https://devzero.io/dashboard
+
+Docs: https://docs.devzero.io
+
+## Requirements
+
+- [Terraform](https://www.terraform.io/downloads.html)
+
+## Using the module
+
+A module to add a cluster to your devzero account
+
+Requires `devzero-inc/devzero` and `hashicorp/helm`
+
+```hcl
+provider "devzero" {
+    team_id = "YOUR_TEAM_ID"
+    token = "YOUR_PAT"
+}
+
+module "devzero-cluster" {
+    source = "devzero-inc/cluster"
+
+    cluster_name = "example-cluster"
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_devzero"></a> [devzero](#requirement\_devzero) | >= 0.1.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_devzero"></a> [devzero](#provider\_devzero) | 0.1.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.0.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [devzero_cluster.cluster](https://registry.terraform.io/providers/devzero-inc/devzero/latest/docs/resources/cluster) | resource |
+| [helm_release.devzero_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.zxporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | The cloud provider of the cluster. Supported values: aws, azure, gcp, "". Empty string will be treated as no cloud credentials are required. | `string` | `""` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_containerd_config_path"></a> [containerd\_config\_path](#input\_containerd\_config\_path) | The path to the containerd config | `string` | `null` | no |
+| <a name="input_containerd_socket_path"></a> [containerd\_socket\_path](#input\_containerd\_socket\_path) | The path to the containerd socket | `string` | `null` | no |
+| <a name="input_enable_live_migration_agent"></a> [enable\_live\_migration\_agent](#input\_enable\_live\_migration\_agent) | Whether to enable the live migration agent | `bool` | `false` | no |
+| <a name="input_enable_scheduler"></a> [enable\_scheduler](#input\_enable\_scheduler) | Whether to enable the scheduler | `bool` | `true` | no |
+| <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | The endpoint of the control plane | `string` | `"https://dakr.devzero.io"` | no |
+| <a name="input_operator_annotations"></a> [operator\_annotations](#input\_operator\_annotations) | The annotations to add to the operator | `map(string)` | `{}` | no |
+| <a name="input_operator_extra_values"></a> [operator\_extra\_values](#input\_operator\_extra\_values) | Additional Helm values for the devzero-operator chart (as name->value). | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_provision_prometheus"></a> [provision\_prometheus](#input\_provision\_prometheus) | Whether to provision prometheus | `bool` | `true` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | The runtime of the cluster. Supported values: containerd, rke2, k3s. | `string` | `"containerd"` | no |
+| <a name="input_zxporter_extra_values"></a> [zxporter\_extra\_values](#input\_zxporter\_extra\_values) | Additional Helm values for the zxporter chart (as name->value). | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
+| <a name="output_cluster_token"></a> [cluster\_token](#output\_cluster\_token) | n/a |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Terraform module for adding a cluster to your devzero account
 
-Website: https://devzero.io/dashboard
+[Website](https://devzero.io/dashboard)
 
-Docs: https://docs.devzero.io
-
-## Requirements
-
-- [Terraform](https://www.terraform.io/downloads.html)
+[Docs](https://docs.devzero.io)
 
 ## Using the module
 
@@ -32,6 +28,7 @@ module "devzero-cluster" {
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_devzero"></a> [devzero](#requirement\_devzero) | >= 0.1.1 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.2 |
 

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,10 @@ resource "helm_release" "zxporter" {
     {
       name  = "monitoring.prometheus.enabled"
       value = var.provision_prometheus
+    },
+    {
+      name  = "zxporter.dakrUrl"
+      value = var.endpoint
     }
   ], var.zxporter_extra_values)
 
@@ -73,12 +77,20 @@ resource "helm_release" "devzero_operator" {
       value = var.cloud_provider == ""
     },
     {
+      name  = "operator.endpoint"
+      value = var.endpoint
+    },
+    {
       name  = "scheduler.enabled"
       value = var.enable_scheduler
     },
     {
       name  = "scheduler.controlPlaneToken"
       value = devzero_cluster.cluster.token
+    },
+    {
+      name  = "scheduler.controlPlaneAddress"
+      value = var.endpoint
     },
     {
       name  = "agent.enabled"

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "helm_release" "zxporter" {
   create_namespace = true
   atomic           = true
   wait             = true
-  
+
   set = concat([
     {
       name  = "zxporter.kubeContextName"
@@ -43,11 +43,11 @@ resource "helm_release" "zxporter" {
     }
   ], var.zxporter_extra_values)
 
-  set_sensitive = [ 
+  set_sensitive = [
     {
       name  = "zxporter.clusterToken"
       value = devzero_cluster.cluster.token
-    } 
+    }
   ]
 
   depends_on = [devzero_cluster.cluster]
@@ -105,7 +105,7 @@ resource "helm_release" "devzero_operator" {
     },
   ], var.operator_extra_values)
 
-  set_sensitive = [ 
+  set_sensitive = [
     {
       name  = "operator.clusterToken"
       value = devzero_cluster.cluster.token

--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,6 @@ resource "helm_release" "zxporter" {
       value = var.cluster_name
     },
     {
-      name  = "zxporter.clusterToken"
-      value = devzero_cluster.cluster.token
-    },
-    {
       name  = "zxporter.k8sProvider"
       value = var.cloud_provider
     },
@@ -46,6 +42,13 @@ resource "helm_release" "zxporter" {
       value = var.endpoint
     }
   ], var.zxporter_extra_values)
+
+  set_sensitive = [ 
+    {
+      name  = "zxporter.clusterToken"
+      value = devzero_cluster.cluster.token
+    } 
+  ]
 
   depends_on = [devzero_cluster.cluster]
 }
@@ -65,16 +68,12 @@ resource "helm_release" "devzero_operator" {
       value = var.cloud_provider
     },
     {
-      name  = "operator.clusterToken"
-      value = devzero_cluster.cluster.token
-    },
-    {
       name  = "operator.clusterName"
       value = var.cluster_name
     },
     {
       name  = "operator.noCloudCreds"
-      value = var.cloud_provider == ""
+      value = tostring(var.cloud_provider == "")
     },
     {
       name  = "operator.endpoint"
@@ -83,10 +82,6 @@ resource "helm_release" "devzero_operator" {
     {
       name  = "scheduler.enabled"
       value = var.enable_scheduler
-    },
-    {
-      name  = "scheduler.controlPlaneToken"
-      value = devzero_cluster.cluster.token
     },
     {
       name  = "scheduler.controlPlaneAddress"
@@ -109,6 +104,17 @@ resource "helm_release" "devzero_operator" {
       value = coalesce(var.containerd_socket_path, lookup(local.containerd_socket_path, var.runtime, "/run/containerd/containerd.sock"))
     },
   ], var.operator_extra_values)
+
+  set_sensitive = [ 
+    {
+      name  = "operator.clusterToken"
+      value = devzero_cluster.cluster.token
+    },
+    {
+      name  = "scheduler.controlPlaneToken"
+      value = devzero_cluster.cluster.token
+    }
+  ]
 
   depends_on = [devzero_cluster.cluster]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,102 @@
+locals {
+  containerd_config_path = {
+    containerd = "/etc/containerd/config.toml"
+    rke2       = "/var/lib/rancher/rke2/agent/etc/containerd/config.toml"
+    k3s        = "/var/lib/rancher/k3s/agent/etc/containerd/config.toml"
+  }
+  containerd_socket_path = {
+    containerd = "/run/containerd/containerd.sock"
+    rke2       = "/var/lib/rancher/rke2/agent/containerd/containerd.sock"
+    k3s        = "/var/lib/rancher/k3s/agent/containerd/containerd.sock"
+  }
+}
+
+resource "devzero_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+resource "helm_release" "zxporter" {
+  name             = "zxporter"
+  chart            = "zxporter"
+  repository       = "https://devzero-inc.github.io/helm-charts"
+  namespace        = "devzero"
+  create_namespace = true
+  atomic           = true
+  wait             = true
+  
+  set = concat([
+    {
+      name  = "zxporter.kubeContextName"
+      value = var.cluster_name
+    },
+    {
+      name  = "zxporter.clusterToken"
+      value = devzero_cluster.cluster.token
+    },
+    {
+      name  = "zxporter.k8sProvider"
+      value = var.cloud_provider
+    },
+    {
+      name  = "monitoring.prometheus.enabled"
+      value = var.provision_prometheus
+    }
+  ], var.zxporter_extra_values)
+
+  depends_on = [devzero_cluster.cluster]
+}
+
+resource "helm_release" "devzero_operator" {
+  name             = "devzero-operator"
+  chart            = "dakr-operator"
+  repository       = "https://devzero-inc.github.io/helm-charts"
+  namespace        = "devzero"
+  create_namespace = true
+  atomic           = true
+  wait             = true
+
+  set = concat([
+    {
+      name  = "cloud"
+      value = var.cloud_provider
+    },
+    {
+      name  = "operator.clusterToken"
+      value = devzero_cluster.cluster.token
+    },
+    {
+      name  = "operator.clusterName"
+      value = var.cluster_name
+    },
+    {
+      name  = "operator.noCloudCreds"
+      value = var.cloud_provider == ""
+    },
+    {
+      name  = "scheduler.enabled"
+      value = var.enable_scheduler
+    },
+    {
+      name  = "scheduler.controlPlaneToken"
+      value = devzero_cluster.cluster.token
+    },
+    {
+      name  = "agent.enabled"
+      value = var.enable_live_migration_agent
+    },
+    {
+      name  = "agent.runtime"
+      value = var.runtime
+    },
+    {
+      name  = "agent.containerdConfigPath"
+      value = coalesce(var.containerd_config_path, lookup(local.containerd_config_path, var.runtime, "/etc/containerd/config.toml"))
+    },
+    {
+      name  = "agent.containerdSock"
+      value = coalesce(var.containerd_socket_path, lookup(local.containerd_socket_path, var.runtime, "/run/containerd/containerd.sock"))
+    },
+  ], var.operator_extra_values)
+
+  depends_on = [devzero_cluster.cluster]
+}

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "helm_release" "zxporter" {
     },
     {
       name  = "monitoring.prometheus.enabled"
-      value = var.provision_prometheus
+      value = tostring(var.provision_prometheus)
     },
     {
       name  = "zxporter.dakrUrl"
@@ -81,7 +81,7 @@ resource "helm_release" "devzero_operator" {
     },
     {
       name  = "scheduler.enabled"
-      value = var.enable_scheduler
+      value = tostring(var.enable_scheduler)
     },
     {
       name  = "scheduler.controlPlaneAddress"
@@ -89,7 +89,7 @@ resource "helm_release" "devzero_operator" {
     },
     {
       name  = "agent.enabled"
-      value = var.enable_live_migration_agent
+      value = tostring(var.enable_live_migration_agent)
     },
     {
       name  = "agent.runtime"

--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,12 @@ resource "devzero_cluster" "cluster" {
 resource "helm_release" "zxporter" {
   name             = "zxporter"
   chart            = "zxporter"
-  repository       = "https://devzero-inc.github.io/helm-charts"
+  repository       = "oci://registry-1.docker.io/devzeroinc"
   namespace        = "devzero"
   create_namespace = true
   atomic           = true
   wait             = true
+  version          = "0.0.14"
 
   set = concat([
     {
@@ -56,11 +57,12 @@ resource "helm_release" "zxporter" {
 resource "helm_release" "devzero_operator" {
   name             = "devzero-operator"
   chart            = "dakr-operator"
-  repository       = "https://devzero-inc.github.io/helm-charts"
+  repository       = "oci://registry-1.docker.io/devzeroinc"
   namespace        = "devzero"
   create_namespace = true
   atomic           = true
   wait             = true
+  version          = "0.1.3"
 
   set = concat([
     {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,8 @@
+output "cluster_id" {
+  value = devzero_cluster.cluster.id
+}
+
+output "cluster_token" {
+  value = devzero_cluster.cluster.token
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,6 @@ output "cluster_id" {
 }
 
 output "cluster_token" {
-  value = devzero_cluster.cluster.token
+  value     = devzero_cluster.cluster.token
   sensitive = true
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    devzero = {
+      source  = "devzero-inc/devzero"
+      version = ">= 0.1.1"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 3.0.2"
+    }
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.1.0"
   required_providers {
     devzero = {
       source  = "devzero-inc/devzero"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,86 @@
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+variable "endpoint" {
+  type        = string
+  description = "The endpoint of the control plane"
+  default     = "https://dakr.devzero.io"
+}
+
+variable "cloud_provider" {
+  type        = string
+  description = "The cloud provider of the cluster. Supported values: aws, azure, gcp, \"\". Empty string will be treated as no cloud credentials are required."
+  default     = ""
+  
+  validation {
+    condition     = contains(["aws", "azure", "gcp", ""], var.cloud_provider)
+    error_message = "cloud_provider must be one of: aws, azure, gcp, or empty string (\"\")."
+  }
+}
+
+variable "provision_prometheus" {
+  type        = bool
+  description = "Whether to provision prometheus"
+  default     = true
+}
+
+variable "operator_annotations" {
+  type        = map(string)
+  description = "The annotations to add to the operator"
+  default     = {}
+}
+
+variable "enable_scheduler" {
+  type        = bool
+  description = "Whether to enable the scheduler"
+  default     = true
+}
+
+variable "enable_live_migration_agent" {
+  type        = bool
+  description = "Whether to enable the live migration agent"
+  default     = false
+}
+
+variable "runtime" {
+  type        = string
+  description = "The runtime of the cluster. Supported values: containerd, rke2, k3s."
+  default     = "containerd"
+
+  validation {
+    condition     = contains(["containerd", "rke2", "k3s"], var.runtime)
+    error_message = "runtime must be one of: containerd, rke2, k3s."
+  }
+}
+
+variable "containerd_config_path" {
+  type        = string
+  description = "The path to the containerd config"
+  default = null
+}
+
+variable "containerd_socket_path" {
+  type        = string
+  description = "The path to the containerd socket"
+  default = null
+}
+
+variable "zxporter_extra_values" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Additional Helm values for the zxporter chart (as name->value)."
+  default     = []
+}
+
+variable "operator_extra_values" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Additional Helm values for the devzero-operator chart (as name->value)."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "cloud_provider" {
   type        = string
   description = "The cloud provider of the cluster. Supported values: aws, azure, gcp, \"\". Empty string will be treated as no cloud credentials are required."
   default     = ""
-  
+
   validation {
     condition     = contains(["aws", "azure", "gcp", ""], var.cloud_provider)
     error_message = "cloud_provider must be one of: aws, azure, gcp, or empty string (\"\")."
@@ -52,13 +52,13 @@ variable "runtime" {
 variable "containerd_config_path" {
   type        = string
   description = "The path to the containerd config"
-  default = null
+  default     = null
 }
 
 variable "containerd_socket_path" {
   type        = string
   description = "The path to the containerd socket"
-  default = null
+  default     = null
 }
 
 variable "zxporter_extra_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "provision_prometheus" {
   default     = true
 }
 
-variable "operator_annotations" {
-  type        = map(string)
-  description = "The annotations to add to the operator"
-  default     = {}
-}
-
 variable "enable_scheduler" {
   type        = bool
   description = "Whether to enable the scheduler"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds a Terraform module to provision a DevZero cluster and install zxporter and devzero-operator via Helm. Configurable inputs for runtime, cloud provider, Prometheus, scheduler, containerd paths, annotations, and extra Helm values. Exposes cluster ID and a sensitive cluster token output.

- **Documentation**
  - Expanded README with usage, requirements, and generated inputs/outputs tables; added docs generation support.

- **Chores**
  - Added CI linting for Terraform, updated ignore rules for Terraform artifacts and sensitive files, and added a docs Makefile target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->