### PR TITLE
fix namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "zxporter" {
   name             = "zxporter"
   chart            = "zxporter"
   repository       = "oci://registry-1.docker.io/devzeroinc"
-  namespace        = "devzero"
+  namespace        = "devzero-zxporter"
   create_namespace = true
   atomic           = true
   wait             = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment namespace for the zxporter service from “devzero” to “devzero-zxporter”.
  * No feature or settings changes; functionality remains unchanged.
  * Existing workflows and integrations should continue to operate normally.
  * Monitoring and environment views may reflect the new namespace name.
  * No action required from end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->