### PR TITLE
Enable single opertor to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ module "devzero-cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_devzero"></a> [devzero](#provider\_devzero) | 0.1.1 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.0.2 |
+| <a name="provider_devzero"></a> [devzero](#provider\_devzero) | >= 0.1.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0.2 |
 
 ## Modules
 
@@ -60,12 +60,14 @@ No modules.
 | <a name="input_containerd_config_path"></a> [containerd\_config\_path](#input\_containerd\_config\_path) | The path to the containerd config | `string` | `null` | no |
 | <a name="input_containerd_socket_path"></a> [containerd\_socket\_path](#input\_containerd\_socket\_path) | The path to the containerd socket | `string` | `null` | no |
 | <a name="input_enable_live_migration_agent"></a> [enable\_live\_migration\_agent](#input\_enable\_live\_migration\_agent) | Whether to enable the live migration agent | `bool` | `false` | no |
+| <a name="input_enable_operator"></a> [enable\_operator](#input\_enable\_operator) | Whether to install the devzero-operator component | `bool` | `true` | no |
 | <a name="input_enable_scheduler"></a> [enable\_scheduler](#input\_enable\_scheduler) | Whether to enable the scheduler | `bool` | `true` | no |
+| <a name="input_enable_zxporter"></a> [enable\_zxporter](#input\_enable\_zxporter) | Whether to install the zxporter component | `bool` | `true` | no |
 | <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | The endpoint of the control plane | `string` | `"https://dakr.devzero.io"` | no |
-| <a name="input_operator_extra_values"></a> [operator\_extra\_values](#input\_operator\_extra\_values) | Additional Helm values for the devzero-operator chart (as name->value). | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_operator_extra_values"></a> [operator\_extra\_values](#input\_operator\_extra\_values) | Additional Helm values for the devzero-operator chart (as name->value). | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_provision_prometheus"></a> [provision\_prometheus](#input\_provision\_prometheus) | Whether to provision prometheus | `bool` | `true` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The runtime of the cluster. Supported values: containerd, rke2, k3s. | `string` | `"containerd"` | no |
-| <a name="input_zxporter_extra_values"></a> [zxporter\_extra\_values](#input\_zxporter\_extra\_values) | Additional Helm values for the zxporter chart (as name->value). | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_zxporter_extra_values"></a> [zxporter\_extra\_values](#input\_zxporter\_extra\_values) | Additional Helm values for the zxporter chart (as name->value). | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/examples/custom-values-override.tf
+++ b/examples/custom-values-override.tf
@@ -1,0 +1,66 @@
+# Example: Using extra_values to fully customize Helm chart values
+module "devzero_cluster" {
+  source = ".."
+  
+  cluster_name = "custom-cluster"
+  
+  # Deploy both components with extensive customization
+  enable_zxporter = true
+  enable_operator = true
+  
+  # Override any Helm value for zxporter
+  zxporter_extra_values = [
+    {
+      name  = "zxporter.image.tag"
+      value = "0.0.23"  # Override default chart version
+    },
+    {
+      name  = "zxporter.nodeSelector.workload-type"
+      value = "monitoring"
+    },
+    {
+      name  = "monitoring.prometheus.serviceMonitor.labels.team"
+      value = "platform"
+    },
+    {
+      name  = "tolerations[0].key"
+      value = "monitoring"
+    },
+    {
+      name  = "tolerations[0].operator"
+      value = "Equal"
+    },
+    {
+      name  = "tolerations[0].value"
+      value = "true"
+    },
+    {
+      name  = "tolerations[0].effect"
+      value = "NoSchedule"
+    }
+  ]
+  
+  # Override any Helm value for operator
+  operator_extra_values = [
+    {
+      name  = "operator.image.tag"
+      value = "0.1.10"  # Override default chart version
+    },
+    {
+      name  = "scheduler.resources.requests.cpu"
+      value = "100m"
+    },
+    {
+      name  = "scheduler.resources.requests.memory"
+      value = "128Mi"
+    },
+    {
+      name  = "agent.daemonset.updateStrategy.type"
+      value = "RollingUpdate"
+    },
+    {
+      name  = "agent.daemonset.updateStrategy.rollingUpdate.maxUnavailable"
+      value = "1"
+    }
+  ]
+}

--- a/examples/full-deployment.tf
+++ b/examples/full-deployment.tf
@@ -1,0 +1,32 @@
+# Example: Full deployment with both components (default behavior)
+module "devzero_cluster" {
+  source = ".."
+  
+  cluster_name   = "full-cluster"
+  cloud_provider = "azure"
+  
+  # Both components enabled by default
+  # enable_zxporter = true  # default
+  # enable_operator = true  # default
+  
+  # Configure all features
+  enable_scheduler            = true
+  enable_live_migration_agent = false
+  provision_prometheus        = true
+  runtime                     = "containerd"
+  
+  # Custom configurations for both components
+  zxporter_extra_values = [
+    {
+      name  = "zxporter.logLevel"
+      value = "info"
+    }
+  ]
+  
+  operator_extra_values = [
+    {
+      name  = "operator.resources.limits.memory"
+      value = "1Gi"
+    }
+  ]
+}

--- a/examples/only-cluster.tf
+++ b/examples/only-cluster.tf
@@ -1,0 +1,15 @@
+# Example: Only create the DevZero cluster without any components
+module "devzero_cluster" {
+  source = ".."
+  
+  cluster_name = "minimal-cluster"
+  
+  # Disable both components
+  enable_zxporter = false
+  enable_operator = false
+}
+
+output "cluster_token" {
+  value     = module.devzero_cluster.cluster_token
+  sensitive = true
+}

--- a/examples/only-operator.tf
+++ b/examples/only-operator.tf
@@ -1,0 +1,28 @@
+# Example: Deploy only the operator component
+module "devzero_cluster" {
+  source = ".."
+  
+  cluster_name      = "workload-cluster"
+  cloud_provider    = "gcp"
+  
+  # Enable only operator
+  enable_zxporter = false
+  enable_operator = true
+  
+  # Operator configuration
+  enable_scheduler            = true
+  enable_live_migration_agent = true
+  runtime                     = "k3s"
+  
+  # Custom operator configuration
+  operator_extra_values = [
+    {
+      name  = "operator.logLevel"
+      value = "debug"
+    },
+    {
+      name  = "scheduler.replicas"
+      value = "2"
+    }
+  ]
+}

--- a/examples/only-zxporter.tf
+++ b/examples/only-zxporter.tf
@@ -1,0 +1,26 @@
+# Example: Deploy only zxporter (monitoring/exporter component)
+module "devzero_cluster" {
+  source = ".."
+  
+  cluster_name      = "monitoring-cluster"
+  cloud_provider    = "aws"
+  
+  # Enable only zxporter
+  enable_zxporter = true
+  enable_operator = false
+  
+  # Configure prometheus monitoring
+  provision_prometheus = true
+  
+  # Custom zxporter configuration
+  zxporter_extra_values = [
+    {
+      name  = "resources.limits.memory"
+      value = "512Mi"
+    },
+    {
+      name  = "monitoring.prometheus.retention"
+      value = "30d"
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ resource "devzero_cluster" "cluster" {
 }
 
 resource "helm_release" "zxporter" {
+  count = var.enable_zxporter ? 1 : 0
+
   name             = "zxporter"
   chart            = "zxporter"
   repository       = "oci://registry-1.docker.io/devzeroinc"
@@ -55,6 +57,8 @@ resource "helm_release" "zxporter" {
 }
 
 resource "helm_release" "devzero_operator" {
+  count = var.enable_operator ? 1 : 0
+
   name             = "devzero-operator"
   chart            = "dakr-operator"
   repository       = "oci://registry-1.docker.io/devzeroinc"

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,18 @@ variable "endpoint" {
   default     = "https://dakr.devzero.io"
 }
 
+variable "enable_zxporter" {
+  type        = bool
+  description = "Whether to install the zxporter component"
+  default     = true
+}
+
+variable "enable_operator" {
+  type        = bool
+  description = "Whether to install the devzero-operator component"
+  default     = true
+}
+
 variable "cloud_provider" {
   type        = string
   description = "The cloud provider of the cluster. Supported values: aws, azure, gcp, \"\". Empty string will be treated as no cloud credentials are required."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to selectively enable or disable the operator and zxporter components independently.

* **Documentation**
  * Updated provider version requirements to use flexible minimum constraints.
  * Added five example deployment configurations showing minimal, full, and custom deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->