### PR TITLE
Update operator versions and move them to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ module "devzero-cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_devzero"></a> [devzero](#provider\_devzero) | >= 0.1.1 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0.2 |
+| <a name="provider_devzero"></a> [devzero](#provider\_devzero) | 0.1.5 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.1.1 |
 
 ## Modules
 
@@ -64,9 +64,11 @@ No modules.
 | <a name="input_enable_scheduler"></a> [enable\_scheduler](#input\_enable\_scheduler) | Whether to enable the scheduler | `bool` | `true` | no |
 | <a name="input_enable_zxporter"></a> [enable\_zxporter](#input\_enable\_zxporter) | Whether to install the zxporter component | `bool` | `true` | no |
 | <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | The endpoint of the control plane | `string` | `"https://dakr.devzero.io"` | no |
+| <a name="input_operator_chart_version"></a> [operator\_chart\_version](#input\_operator\_chart\_version) | The Helm chart version for devzero-operator | `string` | `"0.1.14"` | no |
 | <a name="input_operator_extra_values"></a> [operator\_extra\_values](#input\_operator\_extra\_values) | Additional Helm values for the devzero-operator chart (as name->value). | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_provision_prometheus"></a> [provision\_prometheus](#input\_provision\_prometheus) | Whether to provision prometheus | `bool` | `true` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The runtime of the cluster. Supported values: containerd, rke2, k3s. | `string` | `"containerd"` | no |
+| <a name="input_zxporter_chart_version"></a> [zxporter\_chart\_version](#input\_zxporter\_chart\_version) | The Helm chart version for zxporter | `string` | `"0.0.26"` | no |
 | <a name="input_zxporter_extra_values"></a> [zxporter\_extra\_values](#input\_zxporter\_extra\_values) | Additional Helm values for the zxporter chart (as name->value). | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "helm_release" "zxporter" {
   create_namespace = true
   atomic           = true
   wait             = true
-  version          = "0.0.22"
+  version          = var.zxporter_chart_version
 
   set = concat([
     {
@@ -66,7 +66,7 @@ resource "helm_release" "devzero_operator" {
   create_namespace = true
   atomic           = true
   wait             = true
-  version          = "0.1.9"
+  version          = var.operator_chart_version
 
   set = concat([
     {

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,15 @@ variable "operator_extra_values" {
   description = "Additional Helm values for the devzero-operator chart (as name->value)."
   default     = []
 }
+
+variable "zxporter_chart_version" {
+  type        = string
+  description = "The Helm chart version for zxporter"
+  default     = "0.0.26"
+}
+
+variable "operator_chart_version" {
+  type        = string
+  description = "The Helm chart version for devzero-operator"
+  default     = "0.1.14"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable input variables for Helm chart versions (operator and zxporter), allowing users to specify which chart versions to deploy.

* **Chores**
  * Updated provider version constraints: devzero provider (0.1.5), helm provider (3.1.1).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->